### PR TITLE
Change some form handling rules

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -31,6 +31,10 @@ module.exports = {
 
     'jest/no-large-snapshots': 'error',
 
-    'import/no-extraneous-dependencies': ['error', {devDependencies: ['**/*.stories.js', '**/*.test.js']}]
+    'import/no-extraneous-dependencies': ['error', {devDependencies: ['**/*.stories.js', '**/*.test.js']}],
+    "jsx-a11y/label-has-for": 0, // this is deprecated in future versions so disable now
+    "jsx-a11y/label-has-associated-control": [ 2, {
+      "assert": "either", // fs-styles does not support nesting currently
+    }],
   },
 }


### PR DESCRIPTION
jsx-a11y/label-has-for is deprecated in future versions of eslint so we should disable it now in favor of label-as-associated control
https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md

fs-styles currently does not support nesting, so the default `assert` setting of both is too strict. Switching to `either` allows either nesting or using a `for` or `htmlFor` parameter. Until we move off of fs-styles this will prevent many spurious linting issues.
https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md