### PR TITLE
TS updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 11.0.0-alpha.5 - Feb 27 2023
+
+- Typescript rules update:
+  - All the rules from @typescript-eslint/recommended already turn off the overriden rules, so no-unused-vars and no-empty-functions do not need to be explicitly turned off in our config
+  - Added @typescript-eslint/no-shadow because we have the normal rule for JS files as error.
+
 ## 11.0.0-alpha.4 - Jan 24 2023
 
 - Don't turn import/extensions off for TS files

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/eslint-config-frontier-react",
-  "version": "11.0.0-alpha.4",
+  "version": "11.0.0-alpha.5",
   "description": "A common ESLint configuration setup for frontier apps",
   "main": "index.js",
   "engines": {

--- a/typescript.js
+++ b/typescript.js
@@ -11,10 +11,10 @@ module.exports = {
       rules: {
         'no-use-before-define': 'off', // @typescript-eslint/no-use-before-defined requires this to be off
         '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
-        'no-unused-vars': 'off', // @typescript-eslint/no-unused-vars requires this to be off
-        'no-empty-functions': 'off', // @typescript-eslint/no-empty-function requires this to be off
         '@typescript-eslint/consistent-type-imports': 'error',
         '@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true }],
+        'no-shadow': 'off', // @typescript-eslint/no-shadow requires this to be off
+        '@typescript-eslint/no-shadow': 'error',
       },
     },
     {


### PR DESCRIPTION
All the rules from @typescript-eslint/recommended already turn off the overridden rules, so no-unused-vars and no-empty-functions do not need to be explicitly turned off in our config. The recommended config has @typescript-eslint/no-unused-vars and @typescript-eslint/no-empty-functions as warn and error respectively and so the normal js rules are therefore turned off for TS files.
Added @typescript-eslint/no-shadow because we have the normal rule for JS files as error.

I checked the final config in my app (using npx eslint --print-config file.ts > temp.json) with these changes and it showed what I wrote.