### PR TITLE
Turn off new no-restricted-exports rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 11.0.0-alpha.6 - Mar 1 2023
+
+- Disable no-restricted-exports because we need to be able to export default
+
 ## 11.0.0-alpha.5 - Feb 27 2023
 
 - Typescript rules update:

--- a/es6.js
+++ b/es6.js
@@ -16,6 +16,7 @@ module.exports = {
     requireConfigFile: false,
   },
   rules: {
+    'no-restricted-exports': 'off', // We need to be able to export default
     'no-console': ['warn', { allow: ['error', 'trace', 'time'] }],
     'no-param-reassign': 'off',
     'no-plusplus': 'off',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/eslint-config-frontier-react",
-  "version": "11.0.0-alpha.5",
+  "version": "11.0.0-alpha.6",
   "description": "A common ESLint configuration setup for frontier apps",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
v10 of eslint-config-frontier-react had v17 of eslint-config-airbnb and that did not have the no-restricted-exports rule. eslint-config-airbnb v19 has the no-restricted-exports rule (see https://github.com/airbnb/javascript/compare/eslint-config-airbnb-v18.2.1...eslint-config-airbnb-v19.0.0)

They restrict us allowing to export default and then. We export default a lot currently and I cannot see how to get around it. Neither do I think it is worth it to look. So I think this rule should be turned off.

This is what the rule looks like being enforced in our tree-person-r9 repo where we need default for zion's cache.

![image](https://user-images.githubusercontent.com/77301861/222332779-f7e94ad6-9123-46b1-8c59-0092f724ade8.png)


In zion, all of these would get red squigglies.
![image](https://user-images.githubusercontent.com/77301861/222332832-52eaae48-8d4f-4bb1-be3d-79e1184a61b4.png)
