### PR TITLE
Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/eslint-config-frontier-react",
-  "version": "11.0.0-alpha.7",
+  "version": "11.0.0-alpha.8",
   "description": "A common ESLint configuration setup for frontier apps",
   "main": "index.js",
   "engines": {
@@ -34,29 +34,29 @@
     "eslint": "^7.32.0 || ^8.2.0"
   },
   "dependencies": {
-    "@babel/core": "^7.20.7",
-    "@babel/eslint-parser": "^7.19.1",
+    "@babel/core": "^7.21.3",
+    "@babel/eslint-parser": "^7.21.3",
     "@babel/eslint-plugin": "^7.19.1",
     "@babel/preset-react": "^7.18.6",
     "@fs/eslint-plugin-zion": "^1.4.0",
-    "@typescript-eslint/eslint-plugin": "^5.47.1",
-    "@typescript-eslint/parser": "^5.47.1",
+    "@typescript-eslint/eslint-plugin": "^5.55.0",
+    "@typescript-eslint/parser": "^5.55.0",
     "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-prettier": "^8.5.0",
+    "eslint-config-prettier": "^8.7.0",
     "eslint-plugin-html": "^7.1.0",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jest": "^27.1.7",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-jest-dom": "^4.0.3",
-    "eslint-plugin-jsdoc": "^39.6.4",
+    "eslint-plugin-jsdoc": "^40.0.2",
     "eslint-plugin-json": "^3.1.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-no-autofix": "0.0.3",
     "eslint-plugin-prettier": "^4.2.1",
-    "eslint-plugin-react": "^7.31.11",
+    "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-testing-library": "^5.9.1",
+    "eslint-plugin-testing-library": "^5.10.2",
     "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0",
-    "prettier": "^2.8.1"
+    "prettier": "^2.8.4"
   },
   "devDependencies": {
     "@fs/npm-publisher": "^1.5.1"

--- a/prettierConfig.js
+++ b/prettierConfig.js
@@ -1,0 +1,2 @@
+// See https://prettier.io/docs/en/options.html
+module.exports = { printWidth: 120, singleQuote: true, semi: false }

--- a/prettierSetup.js
+++ b/prettierSetup.js
@@ -1,16 +1,10 @@
 // this is following the pattern defined here
 // https://github.com/prettier/eslint-plugin-prettier#recommended-configuration
+const prettierConfig = require('./prettierConfig')
+
 module.exports = {
   extends: ['plugin:prettier/recommended'],
   rules: {
-    'prettier/prettier': [
-      'warn',
-      {
-        arrowParens: 'always',
-        printWidth: 120,
-        semi: false,
-        singleQuote: true,
-      },
-    ],
+    'prettier/prettier': ['warn', prettierConfig],
   },
 }


### PR DESCRIPTION
Update eslint-plugin-jsdoc to v40 from v39.
Move prettier config to its own file.
Now that v2 of prettier is required due to peerDep of eslint-plugin-prettier v4, and v2 of prettier has arrowParens as always for the default config (https://prettier.io/docs/en/options.html#arrow-function-parentheses), we don't need to specify that override anymore.