### PR TITLE
Update import/no-extraneous-dependencies rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 11.0.0-alpha.9 - May 11 2023
+
+- Update import/no-extraneous-dependencies rule to include types and add more directories and files to be included in the devDeps list
+
+## 11.0.0-alpha.8 - Mar 14 2023
+
+- Separate Prettier's config into a separate file
+- Update eslint-plugin-jsdoc to v40
+
 ## 11.0.0-alpha.7 - Mar 7 2023
 
 - Update JSDoc rules

--- a/es6.js
+++ b/es6.js
@@ -32,13 +32,15 @@ module.exports = {
       {
         devDependencies: [
           '**/setupTests.[tj]s?(x)',
-          '**/*.stories.[tj]s?(x)',
-          '**/*.test.[tj]s?(x)',
-          '**/*.spec.[tj]s?(x)',
+          '**/*.{cy,spec,stories,test}.[tj]s?(x)',
+          '.storybook/**',
           '**/demo/**',
           '**/docs/**',
           '**/fixtures/**',
+          'scripts/**',
+          'cypress/**',
         ],
+        includeTypes: true,
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/eslint-config-frontier-react",
-  "version": "11.0.0-alpha.8",
+  "version": "11.0.0-alpha.9",
   "description": "A common ESLint configuration setup for frontier apps",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Include type imports for no-extraneous-dependencies - This makes it so that we get an error when an import uses type to import something that it needs to have in its deps and it doesn't.

include storybook, scripts, and cypress directories, and cy files for devDependencies since those are not for production