### PR TITLE
Update Deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/eslint-config-frontier-react",
-  "version": "11.0.0-alpha.9",
+  "version": "11.0.0-alpha.10",
   "description": "A common ESLint configuration setup for frontier apps",
   "main": "index.js",
   "engines": {
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/fs-webdev/eslint-config-frontier-react#readme",
   "peerDependencies": {
+    "@testing-library/dom": "^8.0.0 || ^9.0.0",
     "eslint": "^7.32.0 || ^8.2.0"
   },
   "dependencies": {
@@ -39,24 +40,24 @@
     "@babel/eslint-plugin": "^7.19.1",
     "@babel/preset-react": "^7.18.6",
     "@fs/eslint-plugin-zion": "^1.4.0",
-    "@typescript-eslint/eslint-plugin": "^5.55.0",
-    "@typescript-eslint/parser": "^5.55.0",
+    "@typescript-eslint/eslint-plugin": "^6.2.1",
+    "@typescript-eslint/parser": "^6.2.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.7.0",
     "eslint-plugin-html": "^7.1.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^27.2.1",
-    "eslint-plugin-jest-dom": "^4.0.3",
+    "eslint-plugin-jest-dom": "^5.0.1",
     "eslint-plugin-jsdoc": "^40.0.2",
     "eslint-plugin-json": "^3.1.0",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-no-autofix": "0.0.3",
-    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-prettier": "^5.0.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-testing-library": "^5.10.2",
     "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0",
-    "prettier": "^2.8.4"
+    "prettier": "^3.0.0"
   },
   "devDependencies": {
     "@fs/npm-publisher": "^1.5.1"

--- a/prettierConfig.js
+++ b/prettierConfig.js
@@ -1,2 +1,2 @@
 // See https://prettier.io/docs/en/options.html
-module.exports = { printWidth: 120, singleQuote: true, semi: false }
+module.exports = { printWidth: 120, singleQuote: true, semi: false, trailingComma: 'es5' }

--- a/typescript.js
+++ b/typescript.js
@@ -7,7 +7,7 @@ module.exports = {
       files: ['*.ts?(x)'],
       parser: '@typescript-eslint/parser',
       parserOptions: { warnOnUnsupportedTypeScriptVersion: false },
-      extends: ['plugin:@typescript-eslint/recommended'],
+      extends: ['plugin:@typescript-eslint/recommended', 'plugin:@typescript-eslint/stylistic'],
       rules: {
         'no-use-before-define': 'off', // @typescript-eslint/no-use-before-defined requires this to be off
         '@typescript-eslint/no-use-before-define': ['error', { functions: false }],
@@ -15,12 +15,6 @@ module.exports = {
         '@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true }],
         'no-shadow': 'off', // @typescript-eslint/no-shadow requires this to be off
         '@typescript-eslint/no-shadow': 'error',
-      },
-    },
-    {
-      files: ['*.test.ts?(x)'],
-      rules: {
-        '@typescript-eslint/no-non-null-assertion': 'off', // We can know for sure if something is null or not for tests because we made the mock data
       },
     },
   ],

--- a/typescript.js
+++ b/typescript.js
@@ -15,6 +15,7 @@ module.exports = {
         '@typescript-eslint/explicit-function-return-type': ['error', { allowExpressions: true }],
         'no-shadow': 'off', // @typescript-eslint/no-shadow requires this to be off
         '@typescript-eslint/no-shadow': 'error',
+        '@typescript-eslint/consistent-type-definitions': 'off',
       },
     },
   ],


### PR DESCRIPTION
Updates prettier to v3. trailingComma now defaults to all instead of es5. I think we would be fine with that, but I elected to not stir the pot with that for now.

updates eslint-plugin-prettier which supports prettier v3.

updates eslint-plugin-jest-dom which now requires a peerDep of @testing-library/dom@^8.0.0 || ^9.0.0 So added that peerDep rather than adding it as a dep.

updates @typescript-eslint/eslint-plugin and @typescript-eslint/parser:
Diff patch from v5's recommended to v6's recommended and stylistic configs: (https://typescript-eslint.io/blog/announcing-typescript-eslint-v6/)
{
   '@typescript-eslint/adjacent-overload-signatures': '...',
\+  '@typescript-eslint/array-type': '...',
   '@typescript-eslint/ban-ts-comment': '...',
\+  '@typescript-eslint/ban-tslint-comment': '...',
   '@typescript-eslint/ban-types': '...',
\+  '@typescript-eslint/class-literal-property-style': '...',
\+  '@typescript-eslint/consistent-generic-constructors': '...',
\+  '@typescript-eslint/consistent-indexed-object-style': '...',
\+  '@typescript-eslint/consistent-type-assertions': '...',
\+  '@typescript-eslint/consistent-type-definitions': '...',
   'no-array-constructor': '...',
   '@typescript-eslint/no-array-constructor': '...',
\+  '@typescript-eslint/no-confusing-non-null-assertion': '...',
\+  '@typescript-eslint/no-duplicate-enum-values': '...',
   'no-empty-function': '...',
   '@typescript-eslint/no-empty-function': '...',
   '@typescript-eslint/no-empty-interface': '...',
   '@typescript-eslint/no-explicit-any': '...',
   '@typescript-eslint/no-extra-non-null-assertion': '...',
\-  'no-extra-semi': '...',
\-  '@typescript-eslint/no-extra-semi': '...',
   '@typescript-eslint/no-inferrable-types': '...',
   'no-loss-of-precision': '...',
   '@typescript-eslint/no-loss-of-precision': '...',
   '@typescript-eslint/no-misused-new': '...',
   '@typescript-eslint/no-namespace': '...',
   '@typescript-eslint/no-non-null-asserted-optional-chain': '...',
\-  '@typescript-eslint/no-non-null-assertion': '...',
   '@typescript-eslint/no-this-alias': '...',
   '@typescript-eslint/no-unnecessary-type-constraint': '...',
\+  '@typescript-eslint/no-unsafe-declaration-merging': '...',
   'no-unused-vars': '...',
   '@typescript-eslint/no-unused-vars': '...',
   '@typescript-eslint/no-var-requires': '...',
   '@typescript-eslint/prefer-as-const': '...',
\+  '@typescript-eslint/prefer-for-of': '...',
\+  '@typescript-eslint/prefer-function-type': '...',
   '@typescript-eslint/prefer-namespace-keyword': '...',
   '@typescript-eslint/triple-slash-reference': '...',
}

This meant that we could remove the override for @typescript-eslint/no-non-null-assertion
@typescript-eslint/consistent-type-definitions defaults to using interfaces for objects. We mostly use types, and sometimes interfaces. I decided to not have that new styleistic change added in right now.

Did not update eslint-plugin-no-autofix from 0.0.3 to 1.2.3; this is not used currently so I will let someone else update if they want.

Did not update eslint-plugin-jsdoc from 40.3.0 to 46.4.5; they like to do lots of major bumping and I don't care about jsdoc enough to see if all that is fine.