### PR TITLE
Move jest and testing-library recommended rules to only  .test files

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -1,18 +1,23 @@
 module.exports = {
-  extends: ['plugin:jest/recommended', 'plugin:jest-dom/recommended', 'plugin:testing-library/react'],
   plugins: ['@fs/zion'],
   rules: {
-    'jest/no-large-snapshots': 'error',
     '@fs/zion/prefer-zion-render': 'off',
-    'testing-library/no-debugging-utils': 'off',
   },
   overrides: [
     {
       files: ['*.test.[tj]s?(x)'],
+      extends: ['plugin:jest-dom/recommended', 'plugin:testing-library/react'],
       rules: {
+        'jest/no-large-snapshots': 'error',
+        'testing-library/no-debugging-utils': 'off',
         'testing-library/no-node-access': 'off', // TODO this rule was enabled for new testing-library
         'jest/expect-expect': ['warn', { assertFunctionNames: ['expect', '*expect*'] }],
       },
+    },
+    {
+      files: ['*'],
+      excludedFiles: ['cypress/**/*', '*.cy.[tj]s?(x)'],
+      extends: ['plugin:jest/recommended'],
     },
   ],
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/eslint-config-frontier-react",
-  "version": "11.0.0-alpha.10",
+  "version": "11.0.0-alpha.11",
   "description": "A common ESLint configuration setup for frontier apps",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION

plugin:jest/recommended is kept for all files except cypress files because various files can still use the jest global variable

This should make it so we don't get not applicable eslint errors/warnings for jest things