### PR TITLE
[v11] add support for logical-over-directional rule

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -2,6 +2,8 @@ module.exports = {
   plugins: ['@fs/zion'],
   rules: {
     '@fs/zion/prefer-zion-render': 'off',
+    // TODO: consider renaming this file since it effects more than Jest tests
+    '@fs/zion/logical-over-directional': 'warn',
   },
   overrides: [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/eslint-config-frontier-react",
-  "version": "11.1.0",
+  "version": "11.2.0",
   "description": "A common ESLint configuration setup for frontier apps",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@babel/eslint-parser": "^7.22.15",
     "@babel/eslint-plugin": "^7.22.10",
     "@babel/preset-react": "^7.22.15",
-    "@fs/eslint-plugin-zion": "^1.5.0",
+    "@fs/eslint-plugin-zion": "^1.6.1",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
     "eslint-config-airbnb": "^19.0.4",


### PR DESCRIPTION
This updates the v11 branch to use the latest (v1.6.1) of `@fs/eslint-plugin-zion`, which has the ` logical-over-directional` rule.

We decided to make it a `warn` level, since we don't have autofixing enabled yet. Later, we will and then we can turn this into an `error`.

Here is what it looks like linked to Zion:

<img width="955" alt="Screenshot 2024-09-18 at 7 14 48 AM" src="https://github.com/user-attachments/assets/7dd4a315-0b2b-4a77-bc14-aa63296b3ca5">

<img width="802" alt="Screenshot 2024-09-18 at 7 16 06 AM" src="https://github.com/user-attachments/assets/ede2136d-4a18-4b5c-a43e-7531d7d88a79">
