### PR TITLE
[v10] add support for logical-over-directional rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/eslint-config-frontier-react",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "description": "A common ESLint configuration setup for frontier apps",
   "main": "index.js",
   "engines": {
@@ -36,7 +36,7 @@
     "typescript": ">=3"
   },
   "dependencies": {
-    "@fs/eslint-plugin-zion": "^1.2.1",
+    "@fs/eslint-plugin-zion": "^1.6.1",
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.6.0",
     "babel-eslint": "^10.0.1",

--- a/test-helpers.js
+++ b/test-helpers.js
@@ -8,5 +8,8 @@ module.exports = {
   rules: {
     '@fs/zion/prefer-zion-render': 'off',
     'testing-library/no-debugging-utils': 'off',
+    
+    // TODO: consider renaming this file since it effects more than Jest tests
+    '@fs/zion/logical-over-directional': 'warn',
   },
 }


### PR DESCRIPTION
Companion to #50 

I had some trouble getting the linking to work locally, but when I copy/paste this into node_modules it works fine.

Here is what it looks like in `search-react`:

<img width="865" alt="Screenshot 2024-09-18 at 9 23 53 AM" src="https://github.com/user-attachments/assets/a8db1721-6331-402a-a04f-16b73cf67c05">
