### PR TITLE
move plugins that we extend to peer deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 11.3.0 - 2025-05-09
+
+- Refactor dependencies to use peer deps for plugins that we extend
+
 ## 11.1.0 - 2024-08-15
 
 - Include cypress config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/eslint-config-frontier-react",
-  "version": "11.2.2",
+  "version": "11.3.0",
   "description": "A common ESLint configuration setup for frontier apps",
   "main": "index.js",
   "engines": {
@@ -32,18 +32,7 @@
   "homepage": "https://github.com/fs-webdev/eslint-config-frontier-react#readme",
   "peerDependencies": {
     "@testing-library/dom": "^8.0.0 || ^9.0.0",
-    "eslint": "^7.32.0 || ^8.2.0"
-  },
-  "dependencies": {
-    "@babel/core": "^7.23.2",
-    "@babel/eslint-parser": "^7.22.15",
-    "@babel/eslint-plugin": "^7.22.10",
-    "@babel/preset-react": "^7.22.15",
-    "@fs/eslint-plugin-zion": "^1.6.1",
-    "@typescript-eslint/eslint-plugin": "^6.9.1",
-    "@typescript-eslint/parser": "^6.9.1",
-    "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-prettier": "^9.0.0",
+    "eslint": "^7.32.0 || ^8.2.0",
     "eslint-plugin-cypress": "^3.5.0",
     "eslint-plugin-html": "^7.1.0",
     "eslint-plugin-import": "^2.29.0",
@@ -57,7 +46,18 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-testing-library": "^6.1.0",
-    "eslint-plugin-you-dont-need-lodash-underscore": "^6.13.0",
+    "eslint-plugin-you-dont-need-lodash-underscore": "^6.13.0"
+  },
+  "dependencies": {
+    "@babel/core": "^7.23.2",
+    "@babel/eslint-parser": "^7.22.15",
+    "@babel/eslint-plugin": "^7.22.10",
+    "@babel/preset-react": "^7.22.15",
+    "@fs/eslint-plugin-zion": "^1.6.1",
+    "@typescript-eslint/eslint-plugin": "^6.9.1",
+    "@typescript-eslint/parser": "^6.9.1",
+    "eslint-config-airbnb": "^19.0.4",
+    "eslint-config-prettier": "^9.0.0",
     "prettier": "^3.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Depending on the deps of the host app, sometimes they get errors that certain plugins can't be found. It appears plugins that are just dependencies of a dev dep are not reliably put at the node_modules root, whereas peer deps are provided/installed by npm at the project level and are found when eslint runs.

This moves the plugins that we extend into peer deps so the host app will have them appropriately available when eslint runs, which should avoid those errors.