### PR TITLE
Turn off clone-deep rule

### DIFF
--- a/dont-need-lodash.js
+++ b/dont-need-lodash.js
@@ -13,5 +13,6 @@ module.exports = {
     'you-dont-need-lodash-underscore/throttle': 'off',
     'you-dont-need-lodash-underscore/extend': 'off',
     'you-dont-need-lodash-underscore/pickBy': 'off',
+    'you-dont-need-lodash-underscore/clone-deep': 'off', // We'd rather turn off this ESLint rule instead of polyfilling for the 7% unsupported environments https://caniuse.com/?search=structuredclone
   },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/eslint-config-frontier-react",
-  "version": "11.4.1",
+  "version": "11.4.2",
   "description": "A common ESLint configuration setup for frontier apps",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
We aren't ready to move to structuredClone yet.

Frontier and search web brought up concerns with going to structuredClone. Instead of turning off rules individually, let's turn it off for the org.

resolve https://icseng.atlassian.net/browse/FRONTIER-1874 https://icseng.atlassian.net/browse/FSS-11784
https://icseng.atlassian.net/browse/GINKGO-877
https://icseng.atlassian.net/browse/TREEWEB-8936
and https://icseng.atlassian.net/browse/FSSM24Q2-29