### PR TITLE
Include typescript config in default export

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = {
     '@fs/eslint-config-frontier-react/jest',
     '@fs/eslint-config-frontier-react/cypress',
     '@fs/eslint-config-frontier-react/dont-need-lodash',
+    '@fs/eslint-config-frontier-react/typescript',
     '@fs/eslint-config-frontier-react/prettierSetup', // Always have prettier last so it can override format rules in the extends before it
   ],
   overrides: [{ files: ['src/**'], extends: ['@fs/eslint-config-frontier-react/esx'] }],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fs/eslint-config-frontier-react",
-  "version": "11.5.0",
+  "version": "11.6.0",
   "description": "A common ESLint configuration setup for frontier apps",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Now that apps can support TS, our default config should also support it. This would resolve https://familysearch.slack.com/archives/C0FPL3ZL7/p1773697628807119